### PR TITLE
Add vercel.json to silence notifications, allow public access to logs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "public": true,
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
This should reduce the spam we get from Vercel for all the PR preview builds.  It also allows the build logs to be accessed by the public vs only @CameronGray1210, which is helpful for debugging build errors in PRs.