### PR TITLE
Fix #16. Add maxHeadingLevel to tableOfContents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,6 +22,9 @@ module.exports = {
         srcDark: 'img/logo-dark.svg',
       },
     },
+    tableOfContents: {
+      maxHeadingLevel: 4,
+    },
     footer: {
       style: 'dark',
       links: [


### PR DESCRIPTION
Fixes #16 

This PR adds `maxHeadingLevel` to 4 to allow `<h4>` in the table of contents.

After making this change I noticed that some of the sections can look a bit messy. For example in `docs/B-Computations/logic.md`:

<img width="231" alt="Screen Shot 2021-11-01 at 11 00 56 AM" src="https://user-images.githubusercontent.com/53121061/139694842-d47b3c97-c2f0-4283-80e1-60adc5df1471.png">

Some of the `Example` subtitles could be changed to **bold** instead of `<h4>`. Let me know what you think.

