### PR TITLE
Fix #35: Replace h4 to bold for all Examples

### DIFF
--- a/docs/B-Computations/a-simple-calculation.md
+++ b/docs/B-Computations/a-simple-calculation.md
@@ -34,7 +34,7 @@ To define a numeric constant in hexadecimal representation, we prefix the value 
 const int x = 0x5C;  // same as     const int x = 92;
 ```
 
-#### Example
+**Example**
 
 To define the constant pi \(π\) to 8 significant digits, we select the float type and write
 
@@ -103,7 +103,7 @@ A more complete table is listed in the chapter entitled [Input and Output](../F-
 
 _**address**_ contains the address of the destination variable.  We use the prefix & to refer to the 'address of' of a variable. 
 
-#### Example \(continued\)
+**Example \(continued\)**
 
 To accept the radius of the circle, we write
 
@@ -179,7 +179,7 @@ C compilers reject statements such as:
 4 = age;  // *** ERROR cannot set 4 to the value in age ***
 ```
 
-#### Example \(continued\)
+**Example \(continued\)**
 
 Adding the statements to store the area in memory yields:
 
@@ -229,7 +229,7 @@ The default number of decimal places displayed by **`%f`** and **`%lf`** is 6.  
 
 expression is a placeholder for the source variable.  The **`printf()`** procedure copies the variable and converts it into the output text. 
 
-#### Example \(completed\)
+**Example \(completed\)**
 
 The complete program for calculating the area of a circle is:
 

--- a/docs/B-Computations/expressions.md
+++ b/docs/B-Computations/expressions.md
@@ -457,7 +457,7 @@ C compilers promote the operand of lower type in an arithmetic or relational exp
 
 ![](/img/image33.png)
 
-#### Example
+**Example**
 
 ```c
  1034 * 10   evaluates to 10340    // an int result

--- a/docs/B-Computations/logic.md
+++ b/docs/B-Computations/logic.md
@@ -28,14 +28,14 @@ A structured program consists of sets of simple constructs, each of which has on
 
 The simplest example of a structured construct is a _**sequence**_.  A sequence is either a simple statement or a code block.  A _**code block**_ is a set of statements enclosed in a pair of curly braces to be executed sequentially. 
 
-#### Example Simple Statement
+**Example Simple Statement**
 
 ```text
 // single statement (original)
 printf("I like pizza\n");
 ```
 
-#### Example Code Block
+**Example Code Block**
 
 ```text
 // code block (upgrade)
@@ -252,7 +252,7 @@ The _**conditional expression**_ selection construct _****_is shorthand for the 
 
 If the condition is true, the expression evaluates to the operand between **`?`** and **`:`**.  If the condition is false, the expression evaluates to the operand following **`:`**. 
 
-#### Example
+**Example**
 
 ```c
 int main()
@@ -330,7 +330,7 @@ do {
 } while (condition);
 ```
 
-#### Example
+**Example**
 
 ```c
 slices = 4;
@@ -378,7 +378,7 @@ for (initialization; condition; change)
 }
 ```
 
-#### Example
+**Example**
 
 ```c
 for (slices = 4; slices > 0; --slices)
@@ -395,7 +395,7 @@ Flagging is a method of coding iteration constructs within the single-entry sing
 
 Flags are variables that determine whether an iteration continues or stops.  A flag is either true or false.  Flags helps ensure that no paths cross one another.  By introducing a flag, we avoid the jump and multiple exit, obtain a flow chart where no path crosses any other and hence an improved design.
 
-#### Example
+**Example**
 
 The following code snippet uses a flag to terminate the iteration prematurely.
 
@@ -445,7 +445,7 @@ Enclosing one logic construct within another is called _**nesting**_.
 
 A selection within another selection is called a _**nested selection**_.
 
-#### Example
+**Example**
 
 ```c
 if (grade < 50)


### PR DESCRIPTION
Fix #35.

This PR replaces all level 4 heading for Example to **bold**. This removes examples from the table of content.