### PR TITLE
create github actions for deployment

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,0 +1,32 @@
+name: deployment
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  gh-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'yarn'
+      - uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
+      - name: Release to GitHub Pages
+        env:
+          USE_SSH: true
+          GIT_USER: git
+        run: |
+          git config --global user.name ${{ github.actor }}
+          if [ -e yarn.lock ]; then
+            yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+            npm ci
+          else
+            npm i
+          fi
+          yarn deploy

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .docusaurus
 .cache-loader
 
+
 # helper windows batch scripts
 .bat
 
@@ -22,3 +23,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 publish.bat
+
+# intellij configs
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,20 @@ This command generates static content in the `build/` directory and can be serve
 ### Deployment
 
 To build and deploy to GitHub Pages, use:
+1. Follow step 1 - 5 in [Docusaurus's Triggering deployment with GitHub Actions](https://docusaurus.io/docs/deployment)
 
+2. Deploy your site to Github Pages, run:
+- For Bash: 
+```console
+   GIT_USER=<GITHUB_USERNAME> yarn deploy 
+```
+- For Windows
 ```console
 GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
+```
+- For Powershell
+```console
+cmd /C 'set "GIT_USER=<GITHUB_USERNAME>" && yarn deploy'
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
Fix #13 

Create .github/workflows/deployment.yaml to have the production site get updated automatically on every push/merge to the main branch.

Current progress:

* [x] deploy on GH Pages
* [x] update `CONTRIBUTING.md`