### PR TITLE
Audit and fix compilers.md

### DIFF
--- a/docs/A-Introduction/compilers.md
+++ b/docs/A-Introduction/compilers.md
@@ -2,7 +2,7 @@
 id: compilers
 title: Compilers
 sidebar_position: 3
-slug: /A-Introduction/compilers
+slug: /introduction/compilers
 description:  Describe the generations of programming languages, key features of the C language and the C compilers 
 ---
 
@@ -20,7 +20,7 @@ After reading this section, you will be able to:
 
 ## Introduction
 
-We transform the program instructions and program data into the bits and bytes that a computer understands using a compiler.  We write the instructions and provide the data in a programming language that the complier understands. 
+We transform the program instructions and program data into the bits and bytes that a computer understands using a compiler.  We write the instructions and provide the data in a programming language that the compiler understands. 
 
 Programming languages demand completeness and greater precision than human languages.  The ultimate interpreter of any computer program is the hardware.  Hardware cannot interpret intent or nuance, and we need to provide much more detail in our instructions than we do in casual conversations amongst ourselves.  In this sense, programming is a more arduous task than writing a formal report that someone else will read. 
 
@@ -44,8 +44,8 @@ The third, fourth and fifth generation languages are high-level languages.  They
 
 :::note
 
-* [Eric Levenez](http://www.levenez.com/lang/) maintains an up-to-date map of 50 of the more popular languages.
-* [TIOBE Software](http://www.tiobe.com/tpci.htm) tracks the most popular languages and the long-term trends based on world-wide availability of software engineers, courses and third-party vendors as calculated from Google, Bing, Yahoo!, Wikipedia, Amazon, YouTube and Baidu search engines.
+* [Eric Levenez](http://www.levenez.com/lang/ "Computer languages history") maintains an up-to-date map of 50 of the more popular languages.
+* [TIOBE Software](http://www.tiobe.com/tpci.htm "TIOBE Index for November 2021") tracks the most popular languages and the long-term trends based on world-wide availability of software engineers, courses and third-party vendors as calculated from Google, Bing, Yahoo!, Wikipedia, Amazon, YouTube and Baidu search engines.
 
 :::
 
@@ -66,7 +66,7 @@ C serves as an excellent, first programming language for several reasons:
 C programs execute quickly.  Comparative times for a standard test \(Sieve of Eratosthenes\) are:
 
 | Language | Time to Run |
-| :--- | :--- |
+| ---- | ---- |
 | Assembler | 0.18 seconds |
 | C | 2.7 seconds |
 | Basic | 10 seconds |
@@ -159,7 +159,7 @@ The source code listed above includes syntax found in the source code for nearly
 
 ### Documentation
 
-The [comments](/B-Computations/style-guidelines#comments) self-document our source code and enhance its readability. Comments are important in the writing of any program. C supports two styles: multi-line and inline. C compilers ignore all comments.
+The [comments](/B-Computations/style-guidelines#comments "Style guidelines about comments in C") self-document our source code and enhance its readability. Comments are important in the writing of any program. C supports two styles: multi-line and inline. C compilers ignore all comments.
 
 #### Multi-Line Comments
 

--- a/docs/A-Introduction/compilers.md
+++ b/docs/A-Introduction/compilers.md
@@ -42,11 +42,12 @@ There are well over 2500 programming languages and their number continues to inc
 
 The third, fourth and fifth generation languages are high-level languages.  They exhibit no direct connection to any machine language.  Their instructions are more human-like and less machine-like.  A program written in a high-level language is relatively easy to read and relatively easy to port across different platforms. 
 
-**Note**
+:::note
 
 * [Eric Levenez](http://www.levenez.com/lang/) maintains an up-to-date map of 50 of the more popular languages.
 * [TIOBE Software](http://www.tiobe.com/tpci.htm) tracks the most popular languages and the long-term trends based on world-wide availability of software engineers, courses and third-party vendors as calculated from Google, Bing, Yahoo!, Wikipedia, Amazon, YouTube and Baidu search engines.
 
+:::
 
 ###  Features of C
 
@@ -82,7 +83,7 @@ Compilers can optimize the program instructions that we provide to improve execu
 
 ### Examples
 
-Let us write a program that displays the phrase "This is C" and name our source file `hello.c`.  Source files are written in the C language end with the extension `.c`. 
+Let us write a program that displays the phrase "This is C" and name our source file `hello.c`.  Source files written in the C language end with the extension `.c`. 
 
 Copy and paste the following statements into a txt editor of your choice:
 
@@ -94,9 +95,9 @@ Copy and paste the following statements into a txt editor of your choice:
 
  int main(void)               // the starting point of the program
  {
-         printf("This is C"); // send output to the screen
+    printf("This is C"); // send output to the screen
 
-         return 0;            // return control to the operating system
+    return 0;            // return control to the operating system
  }
 ```
 
@@ -114,7 +115,7 @@ gcc hello.c
 
 ![Gcc compiler](https://ict.senecacollege.ca//~ipc144/pages/images/gcc.png)
 
-By default, the gcc compiler produces an output file named a.out.  a.out contains all of the machine language instructions needed to execute the program. 
+By default, the gcc compiler produces an output file named `a.out`. `a.out` contains all of the machine language instructions needed to execute the program. 
 
 To execute these machine language instructions, enter the command:
 
@@ -138,7 +139,7 @@ cl hello.c
 
 ![cl compiler](https://ict.senecacollege.ca//~ipc144/pages/images/cl.png)
 
-By default, the cl compiler produces a file named hello.exe. hello.exe contains all of the machine language instructions needed to execute the program. 
+By default, the cl compiler produces a file named `hello.exe`. `hello.exe` contains all of the machine language instructions needed to execute the program. 
 
 To execute these machine language instructions, enter the command:
 
@@ -188,7 +189,7 @@ Whitespace enhances program readability, for instance, by displaying the structu
 * form feed
 * comments
 
-We may introduce whitespace anywhere except within an identifier or a pair of double-quotes.  In the sample above, main and printf are identifiers.  The blank spaces within "This is C" are not whitespace but characters within the literal string. 
+We may introduce whitespace anywhere except within an identifier or a pair of double-quotes.  In the sample above, `main` and `printf` are identifiers.  The blank spaces within "This is C" are not whitespace but characters within the literal string. 
 
 We preface our source code with comments to identify the program and provide distinguishing information.
 
@@ -211,7 +212,7 @@ When the users or we load the executable code into RAM \(`a.out` or `hello.exe`\
 
 ### Program Output
 
-The following statement outputs `"This is C"` to the standard output device \(for example, the screen\).
+The following statement outputs "This is C" to the standard output device \(for example, the screen\).
 
 ```c
 printf("This is C");

--- a/docs/A-Introduction/compilers.md
+++ b/docs/A-Introduction/compilers.md
@@ -1,5 +1,9 @@
 ---
+id: compilers
+title: Compilers
 sidebar_position: 3
+slug: /A-Introduction/compilers
+description:  Describe the generations of programming languages, key features of the C language and the C compilers 
 ---
 
 # Compilers
@@ -18,11 +22,9 @@ After reading this section, you will be able to:
 
 We transform the program instructions and program data into the bits and bytes that a computer understands using a compiler.  We write the instructions and provide the data in a programming language that the complier understands. 
 
-Programming languages demand completeness and greater precision than human languages.  The ultimate interpreter of any computer program is the hardware.  Hardware cannot interpret intent or nuance and we need to provide much more detail in our instructions than we do in casual conversations amongst ourselves.  In this sense, programming is a more arduous task than writing a formal report that someone else will read. 
+Programming languages demand completeness and greater precision than human languages.  The ultimate interpreter of any computer program is the hardware.  Hardware cannot interpret intent or nuance, and we need to provide much more detail in our instructions than we do in casual conversations amongst ourselves.  In this sense, programming is a more arduous task than writing a formal report that someone else will read. 
 
-### 
-
-![](https://ict.senecacollege.ca//~ipc144/pages/images/languages.png)
+!["Human languages, Programming languages and machine languages" ](https://ict.senecacollege.ca//~ipc144/pages/images/languages.png)
 
 This chapter describes the generations of programming languages, identifies some key features of the C language, describes the compilers that we use to convert programs written in C into binary instructions that hardware can execute and explains the basic syntax found in any C program.
 
@@ -30,7 +32,7 @@ This chapter describes the generations of programming languages, identifies some
 
 ### Generations
 
-There are well over 2500 programming languages and their number continues increasing.  The different generations of programming languages include:
+There are well over 2500 programming languages and their number continues to increase.  The different generations of programming languages include:
 
 1. **Machine languages**.  These are the native languages that the CPU processes.  Each manufacturer of a CPU provides the instruction set for its CPU. 
 2. **Assembly languages**.  These are readable versions of the native machine languages.  Assembly languages simplify coding considerably.  Each manufacturer provides the assembly language for its CPU. 
@@ -43,12 +45,12 @@ The third, fourth and fifth generation languages are high-level languages.  They
 **Note**
 
 * [Eric Levenez](http://www.levenez.com/lang/) maintains an up-to-date map of 50 of the more popular languages.
-* [TIOBE Software](http://www.tiobe.com/tpci.htm) tracks the most popular languages and the long-term trends based on world-wide availability of software engineers, courses and third party vendors as calculated from Google, Bing, Yahoo!, Wikipedia, Amazon, YouTube and Baidu search engines.
+* [TIOBE Software](http://www.tiobe.com/tpci.htm) tracks the most popular languages and the long-term trends based on world-wide availability of software engineers, courses and third-party vendors as calculated from Google, Bing, Yahoo!, Wikipedia, Amazon, YouTube and Baidu search engines.
 
 
 ###  Features of C
 
-C is one of the more popular third-generation languages.  As a procedural language, C requires systematically ordered sets of instructions to perform a computational task and supports the collection of sets of instructions into so-called functions, which can be accessed from multiple points in the same program as required. 
+C is one of the more popular third-generation languages.  As a procedural language, C requires systematically ordered sets of instructions to perform a computational task and supports the collection of sets of instructions into so-called [functions](/D-Modularity/functions "Functions"), which can be accessed from multiple points in the same program as required. 
 
 C serves as an excellent, first programming language for several reasons:
 
@@ -70,17 +72,17 @@ C programs execute quickly.  Comparative times for a standard test \(Sieve of Er
 
 ## The C Compiler
 
-A C compiler is an operating system program that converts C language statements into the machine language equivalents.  A compiler takes a set of program instructions as input and outputs a set of machine language instructions.  We call the input to the compiler our source code and the output from the compiler the binary code.  Once we compile our program, we do not need to re-compile it, unless we have changed the source code in the interim. 
+A C compiler is an operating system program that converts C language statements into machine language equivalents.  A compiler takes a set of program instructions as input and outputs a set of machine language instructions.  We call the input to the compiler our source code and the output from the compiler the binary code.  Once we compile our program, we do not need to recompile it, unless we have changed the source code in the interim. 
 
 To run our program, we direct the operating system to load the binary code into RAM and start executing that code.  The user of our program provides input while that code is executing and receives output from it.
 
-![](https://ict.senecacollege.ca//~ipc144/pages/images/compiler.png)
+![Compiling and executing processes](https://ict.senecacollege.ca//~ipc144/pages/images/compiler.png)
 
 Compilers can optimize the program instructions that we provide to improve execution times. 
 
 ### Examples
 
-Let us write a program that displays the phrase "This is C" and name our source file hello.c.  Source files written in the C language end with the extension .c. 
+Let us write a program that displays the phrase "This is C" and name our source file `hello.c`.  Source files are written in the C language end with the extension `.c`. 
 
 Copy and paste the following statements into a txt editor of your choice:
 
@@ -110,7 +112,7 @@ To create a binary code version of our source code, enter the following command:
 gcc hello.c
 ```
 
-![](https://ict.senecacollege.ca//~ipc144/pages/images/gcc.png)
+![Gcc compiler](https://ict.senecacollege.ca//~ipc144/pages/images/gcc.png)
 
 By default, the gcc compiler produces an output file named a.out.  a.out contains all of the machine language instructions needed to execute the program. 
 
@@ -134,19 +136,19 @@ The C compiler that runs on Windows platforms is called cl. To access this compi
 cl hello.c
 ```
 
-![](https://ict.senecacollege.ca//~ipc144/pages/images/cl.png)
+![cl compiler](https://ict.senecacollege.ca//~ipc144/pages/images/cl.png)
 
-By default, the cl compiler produces a file named hello.exe.  hello.exe contains all of the machine language instructions needed to execute the program. 
+By default, the cl compiler produces a file named hello.exe. hello.exe contains all of the machine language instructions needed to execute the program. 
 
 To execute these machine language instructions, enter the command:
 
-```
+```bash
 hello
 ```
 
 The output of the executed binary will display:
 
-```
+```bash
 This is C
 ```
 
@@ -154,9 +156,9 @@ This is C
 
 The source code listed above includes syntax found in the source code for nearly every C program.
 
-#### Documentation
+### Documentation
 
-The comments self-document our source code and enhance its readability. Comments are important in the writing of any program. C supports two styles: multi-line and inline. C compilers ignore all comments.
+The [comments](/B-Computations/style-guidelines#comments) self-document our source code and enhance its readability. Comments are important in the writing of any program. C supports two styles: multi-line and inline. C compilers ignore all comments.
 
 #### Multi-Line Comments
 
@@ -165,7 +167,7 @@ The comments self-document our source code and enhance its readability. Comments
     hello.c             */
 ```
 
-**/\*** _and **\***_**/** delimit comments that may extend over several lines. Within these delimiters, we may include any character, except the /\* and \*/ pair.
+**`/*`** and **`*/`** delimit comments that may extend over several lines. Within these delimiters, we may include any character, except the `/*` and `*/` pair.
 
 #### Inline Comments
 
@@ -173,7 +175,7 @@ The comments self-document our source code and enhance its readability. Comments
 int main(void)               // the starting point of the program 
 ```
 
-**//** indicates that the following characters until the end of the line.
+**`//`** indicates that the following characters until the end of the line.
 
 #### Whitespace
 
@@ -186,7 +188,7 @@ Whitespace enhances program readability, for instance, by displaying the structu
 * form feed
 * comments
 
-We may introduce whitespace anywhere except within an identifier or a pair of double quotes.  In the sample above, main and printf are identifiers.  The blank spaces within "This is C" are not whitespace but characters within the literal string. 
+We may introduce whitespace anywhere except within an identifier or a pair of double-quotes.  In the sample above, main and printf are identifiers.  The blank spaces within "This is C" are not whitespace but characters within the literal string. 
 
 We preface our source code with comments to identify the program and provide distinguishing information.
 
@@ -196,7 +198,7 @@ By indenting the **`printf("This is C")`** statement and placing it on a separat
 
 ### Program Startup
 
-Every C program includes a clause like int main\(void\). Program execution starts at this line. We call it the program's entry point. The pair of braces follows this clause encompasses the program instructions.
+Every C program includes a clause like `int main(void)`. Program execution starts at this line. We call it the program's entry point. The pair of braces that follow this clause encompasses the program instructions.
 
 ```c
 int main(void)           // program startup
@@ -205,11 +207,11 @@ int main(void)           // program startup
 }
 ```
 
-When we or the users load the executable code into RAM \(a.out or hello.exe\), the operating system transfers control to this entry point. The last statement \(return 0;\) before the closing brace transfers control back to the operating system.
+When the users or we load the executable code into RAM \(`a.out` or `hello.exe`\), the operating system transfers control to this entry point. The last statement \(`return 0;`\) before the closing brace transfers control back to the operating system.
 
 ### Program Output
 
-The following statement outputs "This is C" to the standard output device \(for example, the screen\).
+The following statement outputs `"This is C"` to the standard output device \(for example, the screen\).
 
 ```c
 printf("This is C");


### PR DESCRIPTION
Fixes #43 

* Fix typos, Markdown syntax
* Fix Frontmatter metadata
* Adding  inter-site links to other pages that have related info
* Add alt text on images
* Improve page's Accessibility

