### PR TITLE
Cameron gray1210 sdds domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-cghub.ca
+ipc144.sdds.ca

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 module.exports = {
   title: 'IPC144 - Course Notes',
   tagline: 'C Programming',
-  url: 'https://cghub.ca',
+  url: 'https://ipc144.sdds.ca',
   baseUrl: '/',
   trailingSlash: false,
   onBrokenLinks: 'throw',

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-cghub.ca
+ipc144.sdds.ca


### PR DESCRIPTION
References to the old "cghub.ca" is now updated to point to the "ipc144.sdds.ca" domain in preparation for production builds and releases.