### PR TITLE
Warn on broken links only, don't throw

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   url: 'https://ipc144.sdds.ca',
   baseUrl: '/',
   trailingSlash: false,
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'Seneca-ICTOER',


### PR DESCRIPTION
Part of #106.  This changes our config so that we warn, but don't crash, when doing a production build.  In #107 we can re-enable this; but for now this lets us build things without crashing.