### PR TITLE
Audit and fixed library-functions.md #105

### DIFF
--- a/docs/D-Modularity/library-functions.md
+++ b/docs/D-Modularity/library-functions.md
@@ -143,14 +143,14 @@ The following program outputs a different set of 10 pseudo-random numbers with e
 ```c
 #include <stdlib.h>
 #include <stdio.h>
-#include <time.h> // ...prototype for time(NULL)...
+#include <time.h> // prototype for time(NULL)
 
 int main(void)
 {
         int i;
 
-        srand(time(NULL)); // ...will set a unique seed for each run of the program...
-        for (i = 0; i < 10 ; i++) // ...iterate with “i” as index...
+        srand(time(NULL)); // will set a unique seed for each run of the program
+        for (i = 0; i < 10 ; i++) // iterate with “i” as index
                 printf("Random number %d is %d\n", i+1, rand()); 
 
         return 0;

--- a/docs/D-Modularity/library-functions.md
+++ b/docs/D-Modularity/library-functions.md
@@ -1,5 +1,9 @@
 ---
+id: library-functions
+title: Library Functions
 sidebar_position: 6
+slug: /D-Modularity/library-functions
+description: This chapter describes how to use library functions that include functions for mathematical calculations, generation of random events and manipulation and analysis of character data. To access any function within any library we simply include the appropriate header file for that library and call the function in our source code. 
 ---
 # Library Functions
 

--- a/docs/D-Modularity/library-functions.md
+++ b/docs/D-Modularity/library-functions.md
@@ -11,7 +11,7 @@ After reading this section, you will be able to:
 
 ## Introduction
 
-The standard libraries that support programming languages perform many common tasks.  C compilers ship with the libraries that include functions for mathematical calculations, generation of random events and manipulation and analysis of character data.  To access any function within any library we simply include the appropriate header file for that libray and call the function in our source code. 
+The standard libraries that support programming languages perform many common tasks.  C compilers ship with the libraries that include functions for mathematical calculations, generation of random events and manipulation and analysis of character data.  To access any function within any library we simply include the appropriate header file for that library and call the function in our source code. 
 
 This chapter introduces some of the more common functions in the libraries that ship with C compilers.  The [GNU Documentation](http://www.gnu.org/software/libc/manual/html_node/index.html) includes a comprehensive description of each function in each library.
 
@@ -63,7 +63,7 @@ The above program produces the following output:
 
 ### Random Numbers
 
-`rand()` returns a pseudo-random integer in the range `0` to `RAND_MAX`.  `RAND_MAX` is implementation dependent but **no less** than `32767`.  The prototype for `rand()` is:
+`rand()` returns a pseudo-random integer in the range `0` to `RAND_MAX`.  `RAND_MAX` is implementation-dependent but **no less** than `32767`.  The prototype for `rand()` is:
 
 ```c
 int rand(void);
@@ -139,14 +139,14 @@ The following program outputs a different set of 10 pseudo-random numbers with e
 ```c
 #include <stdlib.h>
 #include <stdio.h>
-#include <time.h> // prototype for time(NULL)
+#include <time.h> // ...prototype for time(NULL)...
 
 int main(void)
 {
         int i;
 
-        srand(time(NULL)); // will set a unique seed for each run of the program
-        for (i = 0; i < 10 ; i++)
+        srand(time(NULL)); // ...will set a unique seed for each run of the program...
+        for (i = 0; i < 10 ; i++) // ...iterate with “i” as index...
                 printf("Random number %d is %d\n", i+1, rand()); 
 
         return 0;
@@ -155,7 +155,7 @@ int main(void)
 
 ### math (Optional)
 
-The math library contains many functions that perform mathematical calculations.  Their prototypes are listed in `<math.h>`.  To compile a program that uses one of these function with the gcc compiler, we add the -lm option to the command line:
+The math library contains many functions that perform mathematical calculations.  Their prototypes are listed in `<math.h>`.  To compile a program that uses one of these functions with the gcc compiler, we add the -lm option to the command line:
 
 ```
 gcc myProgram.c -lm
@@ -429,7 +429,7 @@ Value of x is 1.0001000050
 
 > Note, the cast to a `double` forces floating-point division.
 
-## CHARACTER
+## Character
 
 The `ctype` library contains functions for character manipulation and analysis.  Their prototypes are listed in `<ctype.h>`. 
 
@@ -437,7 +437,7 @@ The `ctype` library contains functions for character manipulation and analysis. 
 
 **tolower**
 
-`tolower()` returns the lower case of the character received, if possible; otherwise the character received unchanged.  The prototype is:
+`tolower()` returns the lower case of the character received, if possible; otherwise, the character received unchanged.  The prototype is:
 
 ```c
 int tolower(int);
@@ -447,7 +447,7 @@ For example, `tolower('D')` returns `'d'`, while `tolower(';')` returns `';'`.
 
 **toupper**
 
-`toupper()` returns the upper case of the character received, if possible; otherwise the character received unchanged.  The prototype is:
+`toupper()` returns the upper case of the character received, if possible; otherwise, the character received unchanged.  The prototype is:
 
 ```c
 int toupper(int);


### PR DESCRIPTION
Part of #18
Audit and fix library-functions.md

Check List

- [x]  Look for any typos -> Found multiple typos and fixed them.
- [x]  Make sure all Markdown is correctly done. The conversion was done automatically by a tool, so there may be more idiomatic ways to do some things -> Fixed uppercase letter to suit all other heading letters.
- [x]  Check the page in a Desktop browser. Does it look OK? Are there any issues that need to be fixed? -> Looks great!
- [x]  Check the page in a Mobile browser. Does it look OK? Are there any issues that need to be fixed? -> Looks great!
- [x]  Try the page in both Light and Dark mode. Are there any issues that need to be fixed? -> Looks great!
- [x]  Try running the page through Lighthouse: developers.google.com/web/tools/lighthouse. Are there any issues that need to be fixed? -> Multiple warnings but no issue found.
- [x]  Try running the page through Web Hint: webhint.io. Are there any issues that need to be fixed? -> Multiple warnings but no issue found.
- [x]  Tables that are really wide (types.md) could be converted to use SVG or flex/grid. Make wide visual tables fit in the available viewport. Another example is the table in docs/D-Modularity/pointers.md, where we should reduce the vertical padding/margins on tables. The tables are too large, and probably shouldn't be tables at all. -> No table found
- [x]  Prefer Markdown tables vs. raw HTML tags -> No table found
- [x]  Fix colours in tables so it uses global styles vs. inline styles -> No table found
- [x]  Use alt tags for all images. See supercooldesign.co.uk/blog/how-to-write-good-alt-text for suggestions -> No images found
- [x]  Avoid blockquote for indentation, and prefer q or blockquote only when actually quoting. Use Admonitions instead. -> nothing found
- [x] Example: docs/D-Modulatirty/pointers.md: there are places where > Blockquote are being used and Admonitions could replace it. “Note:” Lightbulb info Admonition. -> nothing found
- [x]  Make sure images work in dark and light modes. For example, docs/8-Computations/logic.md Flags image is white background, needs to work in dark. Create a “negative” or SVG so we can do Dark Mode? Can we programmatically create this negative? -> nothing found
- [x]  Change colours for tables (don’t use Yellow). We should use the default colour theme. -> nothing found
- [x]  Avoid using and to do emphasis. -> nothing found
- [x]  Use backticks and all code for memory addresses and such in tables that use things like void, int, function names, memory addresses. -> correct use of bacticks
- [x]  Make sure all code blocks use syntax highlighting -> correct use of syntax highlighting, not for outputs to make it look different.
- [x]  centre images horizontally (esp. when they are small) so they work well at all responsive sizes -> nothing found
- [x]  check sub-script and super-script that they are correctly used in all cases -> nothing found
- [x]  consider including inter-site links to other pages that have related info -> Works fine!
- [x]  all links should have descriptive text for accessibility -> accessibility tested!
- [x]  Make sure that sub-headings (right-hand side) for each document are correct. -> fixed heading errors
- [x]  Improve readability of code comments (i.e., // and /.../) in dark mode (even light mode might need some work) -> added some readable comments
- [x]  In places where ... was used as a fourth heading level, use #### instead. -> nothing found
- [x]  Fix Frontmatter for the page to include proper id, title, slug, etc. -> Added it to the file in another commit.