### PR TITLE
Change PWA link name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
               to: '/weeklyContents',
             },
             {
-              html: `<a href='#' id='pwa-button' class='footer__link-item' hidden>Add to Home Screen</a>`,
+              html: `<a href='#' id='pwa-button' class='footer__link-item' hidden>Install as an App</a>`,
             },
           ],
         },


### PR DESCRIPTION
Fixes #136 
- Change PWA link name from: "Add to Home Screen" to: "Install as an App"
![image](https://user-images.githubusercontent.com/58233223/144472807-2893cc16-1179-4adf-93df-484eb0e25978.png)