### PR TITLE
Fix broken links

### DIFF
--- a/docs/A-Introduction/compilers.md
+++ b/docs/A-Introduction/compilers.md
@@ -2,7 +2,6 @@
 id: compilers
 title: Compilers
 sidebar_position: 3
-slug: /introduction/compilers
 description: Describe the generations of programming languages, key features of the C language and the C compilers
 ---
 

--- a/docs/A-Introduction/computers.md
+++ b/docs/A-Introduction/computers.md
@@ -2,7 +2,6 @@
 id: computers
 title: Computers
 sidebar_position: 1
-slug: /introduction/computers
 description: This chapter will teach you about the major components of a modern computer and the software that controls them.
 ---
 

--- a/docs/A-Introduction/information.md
+++ b/docs/A-Introduction/information.md
@@ -2,7 +2,6 @@
 id: information
 title: Information
 sidebar_position: 2
-slug: /introduction/information
 description: The information stored in a computer includes program instructions and program data.
 ---
 

--- a/docs/B-Computations/a-simple-calculation.md
+++ b/docs/B-Computations/a-simple-calculation.md
@@ -2,7 +2,6 @@
 id: a-simple-calculation
 title: A Simple Calculation
 sidebar_position: 2
-slug: /computations/a-simple-calculation
 description: Create a computer program to solve a basic programming task
 ---
 

--- a/docs/B-Computations/expressions.md
+++ b/docs/B-Computations/expressions.md
@@ -2,7 +2,6 @@
 id: expressions
 title: Expressions
 sidebar_position: 3
-slug: /B-computations/expressions
 description: Code various expressions that apply operations on operands of program type
 ---
 

--- a/docs/B-Computations/logic.md
+++ b/docs/B-Computations/logic.md
@@ -2,7 +2,6 @@
 id: logic
 title: Logic
 sidebar_position: 4
-slug: /computations/logic
 description: Selection constructs represent different paths through the set of instructions
 ---
 

--- a/docs/B-Computations/style-guidelines.md
+++ b/docs/B-Computations/style-guidelines.md
@@ -2,7 +2,6 @@
 sidebar_position: 5
 title: Style Guidelines
 id: style-guidelines
-slug: /computations/style-guidelines
 ---
 
 # Style Guidelines

--- a/docs/B-Computations/testing-and-debugging.md
+++ b/docs/B-Computations/testing-and-debugging.md
@@ -2,7 +2,6 @@
 sidebar_position: 6
 id: testing-and-debugging
 title: Testing & Debugging
-slug: /computations/testing-and-debugging
 description: Introduction to testing and debugging in C Language
 ---
 

--- a/docs/C-Data-Structures/arrays.md
+++ b/docs/C-Data-Structures/arrays.md
@@ -2,7 +2,6 @@
 id: arrays
 title: Arrays
 sidebar_position: 1
-slug: /data-structures/arrays
 description: An array is a data structure consisting of an ordered set of elements of common type that are stored contiguously in memory.
 ---
 

--- a/docs/C-Data-Structures/structures.md
+++ b/docs/C-Data-Structures/structures.md
@@ -2,7 +2,6 @@
 id: structures
 title: Structures
 sidebar_position: 2
-slug: /data-structures/structures
 description: A structure type is a collection of not necessarily identical types.
 ---
 

--- a/docs/D-Modularity/functions-arrays-and-structs.md
+++ b/docs/D-Modularity/functions-arrays-and-structs.md
@@ -2,7 +2,6 @@
 id: functions-arrays-and-structs
 title: Functions, Arrays and Structs
 sidebar_position: 3
-slug: /D-Modularity/functions-arrays-and-structs
 description: This chapter describes how to identify a function type, describes the different scopes within a program, describes the passing of arrays and structures to a function, lists style guidelines for function coding and provides a sample walkthrough with functions, pointers and structures.
 ---
 

--- a/docs/D-Modularity/library-functions.md
+++ b/docs/D-Modularity/library-functions.md
@@ -2,7 +2,6 @@
 id: library-functions
 title: Library Functions
 sidebar_position: 6
-slug: /D-Modularity/library-functions
 description: This chapter describes how to use library functions that include functions for mathematical calculations, generation of random events and manipulation and analysis of character data. To access any function within any library we simply include the appropriate header file for that library and call the function in our source code.
 ---
 

--- a/docs/D-Modularity/output-functions.md
+++ b/docs/D-Modularity/output-functions.md
@@ -2,7 +2,6 @@
 sidebar_position: 5
 title: Output Functions
 id: output-functions
-slug: modularity/output-functions
 desctiption: This chapter on output functions is about invoking standard library procedures to stream data to users
 ---
 

--- a/docs/D-Modularity/pointers.md
+++ b/docs/D-Modularity/pointers.md
@@ -2,7 +2,6 @@
 id: pointers
 title: Pointers
 sidebar_position: 2
-slug: /modularity/pointers
 description: A variable that holds an address is called a pointer.
 ---
 

--- a/docs/E-Secondary-Storage/records-and-files.md
+++ b/docs/E-Secondary-Storage/records-and-files.md
@@ -2,7 +2,6 @@
 id: records-and-files
 title: Records and Files
 sidebar_position: 2
-slug: /secondary-storage/records-and-files
 ---
 
 # Records and Files

--- a/docs/F-Refinements/algorithms.md
+++ b/docs/F-Refinements/algorithms.md
@@ -2,7 +2,6 @@
 id: algorithms
 sidebar_position: 6
 title: Algorithms
-slug: /refinements/algorithms
 description: An algorithm is the set of rules that define the sequence of operations required to complete the task.
 ---
 

--- a/docs/F-Refinements/more-input-and-output.md
+++ b/docs/F-Refinements/more-input-and-output.md
@@ -2,7 +2,6 @@
 id: more-input-and-output
 title: More Input and Output
 sidebar_position: 3
-slug: /refinements/more-input-and-output
 description: More on the standard input and output library
 ---
 

--- a/docs/F-Refinements/pointers-arrays-and-structs.md
+++ b/docs/F-Refinements/pointers-arrays-and-structs.md
@@ -2,7 +2,6 @@
 id: pointers-arrays-and-structs
 title: Pointers, Arrays and Structs
 sidebar_position: 4
-slug: /F-Refinements/pointers-arrays-and-structs
 description: A breakdown on the use of pointers, arrays and structures in C
 ---
 

--- a/docs/F-Refinements/portability.md
+++ b/docs/F-Refinements/portability.md
@@ -2,7 +2,6 @@
 id: portability
 title: Portability
 sidebar_position: 7
-slug: /refinements/portability
 description: This chapter describes the portability in C language
 ---
 

--- a/docs/F-Refinements/string-library.md
+++ b/docs/F-Refinements/string-library.md
@@ -2,7 +2,6 @@
 id: string-library
 title: String Library
 sidebar_position: 2
-slug: /refinements/string-library
 description: String library is a standard library to process character strings
 ---
 

--- a/docs/F-Refinements/two-dimensional-arrays.md
+++ b/docs/F-Refinements/two-dimensional-arrays.md
@@ -2,7 +2,6 @@
 id: two-dimensional-arrays
 title: Two-Dimensional Arrays
 sidebar_position: 5
-slug: /refinements/two-dimensional-arrays
 description: This chapter describes the use of two-dimensional arrays
 ---
 

--- a/docs/Resources-Appendices/operators.md
+++ b/docs/Resources-Appendices/operators.md
@@ -2,7 +2,6 @@
 id: operators
 title: Operators
 sidebar_position: 4
-slug: /resources-appendices/operators
 description: Operator Precedence is the order in which operands are bound to operators.
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   url: 'https://ipc144.sdds.ca',
   baseUrl: '/',
   trailingSlash: false,
-  onBrokenLinks: 'warn',
+  onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'Seneca-ICTOER',


### PR DESCRIPTION
Fixes #106 

- By removing slug fixed all the broken links on build
- Enable `onBrokenLinks`  to throw