### PR TITLE
Update style for tables and images

### DIFF
--- a/docs/B-Computations/types.md
+++ b/docs/B-Computations/types.md
@@ -30,209 +30,209 @@ The four most common types of the C language for performing arithmetic calculati
 
 A **`char`** occupies one byte and can store a small integer value, a single character or a single symbol:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="8">char</td>
+            <td colSpan="8">char</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
 
 An **`int`** occupies one word and can store an integer value. In a 32-bit environment, an **`int`** occupies 4 bytes:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="32">int (32-bit environment)</td>
+            <td colSpan="32">int (32-bit environment)</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
           </tr>
     </tbody>
 </table>
 
 A **`float`** typically occupies 4 bytes and can store a single-precision, floating-point number:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="32">float</td>
+            <td colSpan="32">float</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
 
 A **`double`** typically occupies 8 bytes and can store a double-precision, floating-point number:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="64">double</td>
+            <td colSpan="64">double</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
@@ -251,168 +251,168 @@ Specifying the size of an int ensures that the type contains a minimum number of
 
 A **`short int`** \(or simply, a short\) contains at least 16 bits:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="16">short</td>
+            <td colSpan="16">short</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
 
 A **`long int`** \(or simply, a long\) contains at least 32 bits:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="32">long</td>
+            <td colSpan="32">long</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
 
 A **`long long int`** \(or simply, a long long\) contains at least 64 bits:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="64">long long</td>
+            <td colSpan="64">long long</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
@@ -423,86 +423,86 @@ The size of a simple **`int`** is no less than the size of a **`short`**.
 
 The size of a **`long double`** depends on the environment and is typically at least 64 bits:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="64">long double</td>
+            <td colSpan="64">long double</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
@@ -551,10 +551,10 @@ To obtain the 2's complement of an integer, we
 
 For example, we represent the integer -92 by 10100100<sub>2</sub>
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center">Bit #</td>
+            <td>Bit #</td>
             <td>7</td>
             <td>6</td>
             <td>5</td>
@@ -564,41 +564,41 @@ For example, we represent the integer -92 by 10100100<sub>2</sub>
             <td>1</td>
             <td>0</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">92 =></td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
+        <tr className="highlight">
+            <td>92 =></td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">Flip Bits</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">1</td>
-            <td bgcolor="#ffffcc">1</td>
+        <tr className="highlight">
+            <td>Flip Bits</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">Add 1</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">0</td>
-            <td bgcolor="#ffffcc">1</td>
+        <tr className="highlight">
+            <td>Add 1</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>0</td>
+            <td>1</td>
         </tr>
-        <tr>
-            <td align="center">-92 =></td>
+        <tr className="highlight">
+            <td>-92 =></td>
             <td>1</td>
             <td>0</td>
             <td>1</td>
@@ -617,146 +617,146 @@ Floating-point types store tiny as well as huge values by decomposing the values
 
 The most popular model is the IEEE \(I-triple-E or Institute of Electrical and Electronics Engineers\) Standard 754 for Binary and Floating-Point Arithmetic. Under IEEE 754, a float has 32 bits, consisting of one sign bit, an 8-bit exponent and a 23-bit significand \(or mantissa\):
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="32">float</td>
+            <td colSpan="32">float</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
         <tr>
             <td>s</td>
-            <td align="center" colSpan="8">exponent</td>
-            <td align="center" colSpan="23">significand</td>
+            <td colSpan="8">exponent</td>
+            <td colSpan="23">significand</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
 
 Under IEEE 754, a double occupies 64 bits, has one sign bit, an 11-bit exponent and a 52-bit significand:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="64">double</td>
+            <td colSpan="64">double</td>
         </tr>
         <tr>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
-            <td align="center" colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
+            <td colSpan="8">1 Byte</td>
         </tr>
         <tr>
             <td>s</td>
-            <td align="center" colSpan="11">exponent</td>
-            <td align="center" colSpan="52">significand</td>
+            <td colSpan="11">exponent</td>
+            <td colSpan="52">significand</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
-            <td bgcolor="#ffffcc">&nbsp;</td>
+        <tr className="highlight">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
         </tr>
     </tbody>
 </table>
@@ -771,57 +771,57 @@ The number of bytes allocated for a type determines the range of values that tha
 
 The ranges of values for the integral types are shown below. Ranges for some types depend on the execution environment:
 
-<table border="0">
+<table>
     <thead>
         <tr>
-            <td align="center">Type</td>
-            <td align="center">Size</td>
-            <td align="center">Min</td>
-            <td align="center">Max</td>
+            <td>Type</td>
+            <td>Size</td>
+            <td>Min</td>
+            <td>Max</td>
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">char</td>
-            <td bgcolor="#ffffcc" align="center">8 bits</td>
-            <td bgcolor="#ffffcc" align="center">-128</td>
-            <td bgcolor="#ffffcc" align="center">127</td>
+        <tr className="highlight">
+            <td>char</td>
+            <td>8 bits</td>
+            <td>-128</td>
+            <td>127</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">char</td>
-            <td bgcolor="#ffffcc" align="center">8 bits</td>
-            <td bgcolor="#ffffcc" align="center">0</td>
-            <td bgcolor="#ffffcc" align="center">255</td>
+        <tr className="highlight">
+            <td>char</td>
+            <td>8 bits</td>
+            <td>0</td>
+            <td>255</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">short</td>
-            <td bgcolor="#ffffcc" align="center">>= 16 bits</td>
-            <td bgcolor="#ffffcc" align="center">-32,768</td>
-            <td bgcolor="#ffffcc" align="center">32,767</td>
+        <tr className="highlight">
+            <td>short</td>
+            <td>>= 16 bits</td>
+            <td>-32,768</td>
+            <td>32,767</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">int</td>
-            <td bgcolor="#ffffcc" align="center">2 bytes</td>
-            <td bgcolor="#ffffcc" align="center">-32,768</td>
-            <td bgcolor="#ffffcc" align="center">32,767</td>
+        <tr className="highlight">
+            <td>int</td>
+            <td>2 bytes</td>
+            <td>-32,768</td>
+            <td>32,767</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">int</td>
-            <td bgcolor="#ffffcc" align="center">4 bytes</td>
-            <td bgcolor="#ffffcc" align="center">-2,147,483,648</td>
-            <td bgcolor="#ffffcc" align="center">2,147,483,647</td>
+        <tr className="highlight">
+            <td>int</td>
+            <td>4 bytes</td>
+            <td>-2,147,483,648</td>
+            <td>2,147,483,647</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">long</td>
-            <td bgcolor="#ffffcc" align="center">>= 32 bits</td>
-            <td bgcolor="#ffffcc" align="center">-2,147,483,648</td>
-            <td bgcolor="#ffffcc" align="center">2,147,483,647</td>
+        <tr className="highlight">
+            <td>long</td>
+            <td>>= 32 bits</td>
+            <td>-2,147,483,648</td>
+            <td>2,147,483,647</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">long long</td>
-            <td bgcolor="#ffffcc" align="center">>= 64 bits</td>
-            <td bgcolor="#ffffcc" align="center">-9,233,372,036,854,775,808</td>
-            <td bgcolor="#ffffcc" align="center">9,233,372,036,854,775,807</td>
+        <tr className="highlight">
+            <td>long long</td>
+            <td>>= 64 bits</td>
+            <td>-9,233,372,036,854,775,808</td>
+            <td>9,233,372,036,854,775,807</td>
         </tr>
     </tbody>
 </table>
@@ -830,51 +830,51 @@ The ranges of values for the integral types are shown below. Ranges for some typ
 
 The limits on a float and double depend on the execution environment:
 
-<table border="0">
+<table>
     <thead>
         <tr>
-            <td align="center">Type</td>
-            <td align="center">Size</td>
-            <td align="center">Significant</td>
-            <td align="center">Min Exponent</td>
-            <td align="center">Max Exponent</td>
+            <td>Type</td>
+            <td>Size</td>
+            <td>Significant</td>
+            <td>Min Exponent</td>
+            <td>Max Exponent</td>
         </tr>
     </thead>
     <tbody>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">float</td>
-            <td bgcolor="#ffffcc" align="center">minimum</td>
-            <td bgcolor="#ffffcc" align="center">6</td>
-            <td bgcolor="#ffffcc" align="center">-37</td>
-            <td bgcolor="#ffffcc" align="center">37</td>
+        <tr className="highlight">
+            <td>float</td>
+            <td>minimum</td>
+            <td>6</td>
+            <td>-37</td>
+            <td>37</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">float</td>
-            <td bgcolor="#ffffcc" align="center">typical</td>
-            <td bgcolor="#ffffcc" align="center">6</td>
-            <td bgcolor="#ffffcc" align="center">-37</td>
-            <td bgcolor="#ffffcc" align="center">37</td>
+        <tr className="highlight">
+            <td>float</td>
+            <td>typical</td>
+            <td>6</td>
+            <td>-37</td>
+            <td>37</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">double</td>
-            <td bgcolor="#ffffcc" align="center">minimum</td>
-            <td bgcolor="#ffffcc" align="center">10</td>
-            <td bgcolor="#ffffcc" align="center">-37</td>
-            <td bgcolor="#ffffcc" align="center">37</td>
+        <tr className="highlight">
+            <td>double</td>
+            <td>minimum</td>
+            <td>10</td>
+            <td>-37</td>
+            <td>37</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">double</td>
-            <td bgcolor="#ffffcc" align="center">typical</td>
-            <td bgcolor="#ffffcc" align="center">15</td>
-            <td bgcolor="#ffffcc" align="center">-307</td>
-            <td bgcolor="#ffffcc" align="center">307</td>
+        <tr className="highlight">
+            <td>double</td>
+            <td>typical</td>
+            <td>15</td>
+            <td>-307</td>
+            <td>307</td>
         </tr>
-        <tr>
-            <td bgcolor="#ffffcc" align="center">long double</td>
-            <td bgcolor="#ffffcc" align="center">typical</td>
-            <td bgcolor="#ffffcc" align="center">15</td>
-            <td bgcolor="#ffffcc" align="center">-307</td>
-            <td bgcolor="#ffffcc" align="center">307</td>
+        <tr className="highlight">
+            <td>long double</td>
+            <td>typical</td>
+            <td>15</td>
+            <td>-307</td>
+            <td>307</td>
         </tr>
     </tbody>
 </table>

--- a/docs/D-Modularity/functions-arrays-and-structs.md
+++ b/docs/D-Modularity/functions-arrays-and-structs.md
@@ -455,26 +455,26 @@ Grades for 975
 
 The values in the original object, its copy and the local object are shown in the table below:
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center"><code>int main()</code></td>
-    <td align="center" colSpan="2"><code>void set()</code></td></tr>
-<tr><td align="center"><code>struct Student harry</code></td>
-    <td align="center"><code>struct Student st</code></td> 
-    <td align="center"><code>struct Student harry</code></td></tr>
+<tr><td><code>int main()</code></td>
+    <td colSpan="2"><code>void set()</code></td></tr>
+<tr><td><code>struct Student harry</code></td>
+    <td><code>struct Student st</code></td> 
+    <td><code>struct Student harry</code></td></tr>
 </thead>
 <tbody>
-<tr><td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>975 2 50.0f 50.0f</td>
+    <td>975 2 50.0f 50.0f</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td></tr>
+<tr className="highlight"><td>975 2 50.0f 50.0f</td>
+    <td>975 2 50.0f 50.0f</td>
+    <td>306 2 78.9f 91.6f</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-    <td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td></tr>
+<tr className="highlight"><td>975 2 50.0f 50.0f</td>
+    <td>306 2 78.9f 91.6f</td>
+    <td>306 2 78.9f 91.6f</td></tr>
 </tbody>
 </table>
 
@@ -542,37 +542,37 @@ Grades for 306
 
 The values in the original object and the local object are shown in the table below:
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center"><code>int main()</code></td>
-<td align="center" colSpan="2"><code>void set()</code></td>
-<td align="center"><code>void display()</code></td></tr>
+<tr><td><code>int main()</code></td>
+<td colSpan="2"><code>void set()</code></td>
+<td><code>void display()</code></td></tr>
 
-<tr><td align="center"><code>struct Student harry</code></td>
-<td align="center"><code>struct Student *st</code></td>
-<td align="center"><code>struct Student harry</code></td>
-<td align="center"><code>struct Student st</code></td></tr>
+<tr><td><code>struct Student harry</code></td>
+<td><code>struct Student *st</code></td>
+<td><code>struct Student harry</code></td>
+<td><code>struct Student st</code></td></tr>
 </thead>
 <tbody>
-<tr><td align="center">Address:<br/>22ff2b8d4</td>
-<td align="center">&nbsp;<br/>22ff2b8ec</td>
-<td align="center">&nbsp;<br/>22ff2b8f0</td>
-<td align="center">&nbsp;<br/>22ff2b908</td></tr>
+<tr><td>Address:<br/>22ff2b8d4</td>
+<td>&nbsp;<br/>22ff2b8ec</td>
+<td>&nbsp;<br/>22ff2b8f0</td>
+<td>&nbsp;<br/>22ff2b908</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>975 2 50.0f 50.0f</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">2ff2b8d4</td>
-<td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>306 2 78.9f 91.6f</td>
+<td>2ff2b8d4</td>
+<td>306 2 78.9f 91.6f</td>
+<td>&nbsp;</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td>
-<td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td></tr>
+<tr className="highlight"><td>306 2 78.9f 91.6f</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>306 2 78.9f 91.6f</td></tr>
 </tbody>
 </table>
 
@@ -636,37 +636,37 @@ If we **pass by address** with no intention of changing that object within the f
 
 The values in the original object and the local object are shown in the table below:
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center"><code>int main()</code></td>
-    <td align="center" colSpan="2"><code>void set()</code></td>
-    <td align="center"><code>void display()</code></td></tr>
+<tr><td><code>int main()</code></td>
+    <td colSpan="2"><code>void set()</code></td>
+    <td><code>void display()</code></td></tr>
 
-<tr><td align="center"><code>struct Student harry</code></td>
-    <td align="center"><code>struct Student *st</code></td>
-    <td align="center"><code>struct Student harry</code></td>
-    <td align="center"><code>const struct Student *st</code></td></tr>
+<tr><td><code>struct Student harry</code></td>
+    <td><code>struct Student *st</code></td>
+    <td><code>struct Student harry</code></td>
+    <td><code>const struct Student *st</code></td></tr>
 </thead>
 <tbody>
-<tr><td align="center">Address:<br/>22ff2b8d4</td>
-<td align="center">&nbsp;<br/>22ff2b8ec</td>
-<td align="center">&nbsp;<br/>22ff2b8f0</td>
-<td align="center">&nbsp;<br/>22ff2b908</td></tr>
+<tr><td>Address:<br/>22ff2b8d4</td>
+<td>&nbsp;<br/>22ff2b8ec</td>
+<td>&nbsp;<br/>22ff2b8f0</td>
+<td>&nbsp;<br/>22ff2b908</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">975 2 50.0f 50.0f</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>975 2 50.0f 50.0f</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">2ff2b8d4</td>
-<td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>306 2 78.9f 91.6f</td>
+<td>2ff2b8d4</td>
+<td>306 2 78.9f 91.6f</td>
+<td>&nbsp;</td></tr>
 
-<tr><td align="center" bgcolor="#FFFF99">306 2 78.9f 91.6f</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td>
-<td align="center" bgcolor="#FFFF99">&nbsp;</td>
-<td align="center" bgcolor="#FFFF99">2ff2b8d4</td></tr>
+<tr className="highlight"><td>306 2 78.9f 91.6f</td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+<td>2ff2b8d4</td></tr>
 </tbody>
 </table>
 
@@ -836,113 +836,113 @@ The table includes:
 The breakdown of each object into its members in the head of the table. We reserve a separate line for the addresses that are pointed to:
 :::
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center" colSpan="4"><code>int</code></td>
-    <td align="center" colSpan="2"><code>void</code></td>
-    <td align="center" colSpan="4"><code>struct A</code></td></tr>
+<tr><td colSpan="4"><code>int</code></td>
+    <td colSpan="2"><code>void</code></td>
+    <td colSpan="4"><code>struct A</code></td></tr>
 
-<tr><td align="center" colSpan="4"><code>main()</code></td>
-<td align="center" colSpan="2"><code>foo()</code></td>
-<td align="center" colSpan="4"><code>goo()</code></td></tr>
+<tr><td colSpan="4"><code>main()</code></td>
+<td colSpan="2"><code>foo()</code></td>
+<td colSpan="4"><code>goo()</code></td></tr>
 
-<tr><td align="center" colSpan="2"><code>struct A</code></td>
-    <td align="center" colSpan="2"><code>struct A</code></td>
-    <td align="center"><code>struct A*</code></td>
-    <td align="center">&nbsp;</td>
-    <td align="center" colSpan="2"><code>struct A</code></td>
-    <td align="center" colSpan="2"><code>struct A</code></td></tr>
+<tr><td colSpan="2"><code>struct A</code></td>
+    <td colSpan="2"><code>struct A</code></td>
+    <td><code>struct A*</code></td>
+    <td>&nbsp;</td>
+    <td colSpan="2"><code>struct A</code></td>
+    <td colSpan="2"><code>struct A</code></td></tr>
 </thead>
 <tbody>
-<tr><td align="center" colSpan="2">a</td>
-    <td align="center" colSpan="2">b</td>
-    <td align="center">c</td>
-    <td align="center">&nbsp;</td>
-    <td align="center" colSpan="2">d</td>
-    <td align="center" colSpan="2">e</td></tr>
+<tr><td colSpan="2">a</td>
+    <td colSpan="2">b</td>
+    <td>c</td>
+    <td>&nbsp;</td>
+    <td colSpan="2">d</td>
+    <td colSpan="2">e</td></tr>
 
-<tr><td align="center" colSpan="2">Address:<br/>1000</td>
-    <td align="center" colSpan="2">&nbsp;<br/>100C</td>
-    <td align="center">&nbsp;<br/>1018</td>
-    <td align="center">&nbsp;<br/>101C</td>
-    <td align="center" colSpan="2">&nbsp;<br/>1020</td>
-    <td align="center" colSpan="2">&nbsp;<br/>102C</td></tr>
+<tr><td colSpan="2">Address:<br/>1000</td>
+    <td colSpan="2">&nbsp;<br/>100C</td>
+    <td>&nbsp;<br/>1018</td>
+    <td>&nbsp;<br/>101C</td>
+    <td colSpan="2">&nbsp;<br/>1020</td>
+    <td colSpan="2">&nbsp;<br/>102C</td></tr>
 
-<tr><td align="center">int</td>
-    <td align="center">double</td>
-    <td align="center">int</td>
-    <td align="center">double</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">double</td>
-    <td align="center">int</td>
-    <td align="center">double</td></tr>
+<tr><td>int</td>
+    <td>double</td>
+    <td>int</td>
+    <td>double</td>
+    <td>&nbsp;</td>
+    <td>int</td>
+    <td>int</td>
+    <td>double</td>
+    <td>int</td>
+    <td>double</td></tr>
 
-<tr><td align="center">x</td>
-    <td align="center">r</td>
-    <td align="center">x</td>
-    <td align="center">r</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">i</td>
-    <td align="center">x</td>
-    <td align="center">r</td>
-    <td align="center">x</td>
-    <td align="center">r</td></tr>
+<tr><td>x</td>
+    <td>r</td>
+    <td>x</td>
+    <td>r</td>
+    <td>&nbsp;</td>
+    <td>i</td>
+    <td>x</td>
+    <td>r</td>
+    <td>x</td>
+    <td>r</td></tr>
 
-<tr><td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">1000</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>1000</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">1000</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>1000</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">1000</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>1000</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">1000</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>1000</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 
-<tr><td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td align="center" bgcolor="#FFFF99">1000</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td>
-    <td bgcolor="#FFFF99">&nbsp;</td></tr>
+<tr className="highlight"><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>1000</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 </tbody>
 </table>

--- a/docs/D-Modularity/functions.md
+++ b/docs/D-Modularity/functions.md
@@ -46,11 +46,7 @@ The module named `hello.c` starts executing at statement `int main(void)`, outpu
 
 We can sub-divide a programming project in different ways. We select our modules so that each one focuses on a narrower aspect of the project. Our objective is to define a set of modules that simplifies the complexity of the original problem.
 
-<div className="mdImg">
-
 ![modules](/img/modules.png)
-
-</div>
 
 Some general guidelines for defining a module include:
 
@@ -96,11 +92,8 @@ Consider a module that receives a flag from another module and performs a calcul
 
 The C language is a procedural programming language. It supports modular design through function syntax. Functions transfer control between one another. When a function transfers control to another function, we say that it **_calls_** the other function. Once the other function completes its task and transfers control to the caller function, we say that that other function **_returns_** control to its **_caller_**.
 
-<div className="mdImg">
-
 ![function](/img/function.png)
 
-</div>
 In the example from the introductory chapter on [compilers](../A-Introduction/compilers.md) listed above:
 
 1. the `main()` function calls the `printf()` function
@@ -234,12 +227,9 @@ identifier(argument, ..., argument)
 
 `identifer` specifies the function being called, while `argument` specifies a value being passed to the function being called.
 
-<div className="mdImg">
-
 ![calling-functions](/img/calling.png)
 
-</div>
-An argument may be a constant, a variable, or an expression (with certain exceptions).  The number of arguments in a function call should match the number of parameters in the function header.
+An argument may be a constant, a variable, or an expression (with certain exceptions). The number of arguments in a function call should match the number of parameters in the function header.
 
 ### Pass By Value
 
@@ -269,87 +259,87 @@ The C compiler evaluates the cast (coercion) of 2.5 before passing the value of 
 
 The structure of a walkthrough table for a modular program is a simple extension of the structure of the walkthrough table shown in the chapter entitled [Testing and Debugging](../B-Computations/testing-and-debugging.md). The table for a modular program groups the variables under their parent functions.
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center" colSpan="3">int</td>
-<td align="center" colSpan="3">type</td></tr>
-<tr><td align="center" colSpan="3">main(void)</td>
-<td align="center" colSpan="3">--function identifier here--</td></tr>
+<tr><td colSpan="3">int</td>
+<td colSpan="3">type</td></tr>
+<tr><td colSpan="3">main(void)</td>
+<td colSpan="3">--function identifier here--</td></tr>
 </thead>
 <tbody>
-<tr><td align="center">type</td>
-<td align="center">...</td>
-<td align="center">type</td>
-<td align="center">type</td>
-<td align="center">...</td>
-<td align="center">type</td></tr>
-<tr><td align="center">variable z</td>
-<td align="center">...</td>
-<td align="center">variable a</td>
-<td align="center">variable z</td>
-    <td align="center">...</td>
-    <td align="center">variable a</td></tr>
-<tr><td align="center">&amp;z</td>
-    <td align="center">...</td>
-    <td align="center">&amp;a</td>
-    <td align="center">&amp;z</td>
-    <td align="center">...</td>
-    <td align="center">&amp;a</td></tr>
+<tr><td>type</td>
+<td>...</td>
+<td>type</td>
+<td>type</td>
+<td>...</td>
+<td>type</td></tr>
+<tr><td>variable z</td>
+<td>...</td>
+<td>variable a</td>
+<td>variable z</td>
+    <td>...</td>
+    <td>variable a</td></tr>
+<tr><td>&amp;z</td>
+    <td>...</td>
+    <td>&amp;a</td>
+    <td>&amp;z</td>
+    <td>...</td>
+    <td>&amp;a</td></tr>
 <tr><td colSpan="6"></td></tr>
-<tr><td align="center">initial value</td>
-    <td align="center">...</td>
-    <td align="center">initial value</td>
-    <td align="center">initial value</td>
-    <td align="center">...</td>
-    <td align="center">initial value</td></tr>
-<tr><td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">initial value</td>
-    <td align="center">...</td>
-    <td align="center">initial value</td>
-    <td align="center">initial value</td>
-    <td align="center">...</td>
-    <td align="center">initial value</td></tr>
-<tr><td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
-<tr><td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">next value</td>
-    <td align="center">...</td>
-    <td align="center">next value</td></tr>
+<tr><td>initial value</td>
+    <td>...</td>
+    <td>initial value</td>
+    <td>initial value</td>
+    <td>...</td>
+    <td>initial value</td></tr>
+<tr><td>next value</td>
+    <td>...</td>
+    <td>next value</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>next value</td>
+    <td>...</td>
+    <td>next value</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>initial value</td>
+    <td>...</td>
+    <td>initial value</td>
+    <td>initial value</td>
+    <td>...</td>
+    <td>initial value</td></tr>
+<tr><td>next value</td>
+    <td>...</td>
+    <td>next value</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>next value</td>
+    <td>...</td>
+    <td>next value</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
+<tr><td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>next value</td>
+    <td>...</td>
+    <td>next value</td></tr>
 </tbody>
 </table>
 
@@ -365,133 +355,133 @@ The completed walkthrough table for the power.c program listed above is shown be
 
 - **& represents the address.**
 
-<table border="0">
+<table>
 <thead>
-<tr><td align="center" colSpan="3">int</td>
-    <td align="center" colSpan="4">int</td></tr>
-<tr><td align="center" colSpan="3">main(void)</td>
-    <td align="center" colSpan="4">power(int base, int exponent)</td></tr>
+<tr><td colSpan="3">int</td>
+    <td colSpan="4">int</td></tr>
+<tr><td colSpan="3">main(void)</td>
+    <td colSpan="4">power(int base, int exponent)</td></tr>
 </thead>
 <tbody>
-<tr><td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td></tr>
-<tr><td align="center">base</td>
-    <td align="center">exp</td>
-    <td align="center">answer</td>
-    <td align="center">base</td>
-    <td align="center">exponent</td>
-    <td align="center">result</td>
-    <td align="center">i</td></tr>
-<tr><td align="center">&amp;100</td>
-    <td align="center">&amp;104</td>
-    <td align="center">&amp;108</td>
-    <td align="center">&amp;10C</td>
-    <td align="center">&amp;110</td>
-    <td align="center">&amp;114</td>
-    <td align="center">&amp;118</td></tr>
-<tr><td align="center">3</td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center"></td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">1</td>
-    <td align="center"></td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">1</td>
-    <td align="center">0</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">3</td>
-    <td align="center">0</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">3</td>
-    <td align="center">1</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">9</td>
-    <td align="center">1</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">9</td>
-    <td align="center">2</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">27</td>
-    <td align="center">2</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">27</td>
-    <td align="center">3</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center">3</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center"></td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center">4</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td></tr>
+<tr><td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td></tr>
+<tr><td>base</td>
+    <td>exp</td>
+    <td>answer</td>
+    <td>base</td>
+    <td>exponent</td>
+    <td>result</td>
+    <td>i</td></tr>
+<tr><td>&amp;100</td>
+    <td>&amp;104</td>
+    <td>&amp;108</td>
+    <td>&amp;10C</td>
+    <td>&amp;110</td>
+    <td>&amp;114</td>
+    <td>&amp;118</td></tr>
+<tr><td>3</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td></td>
+    <td></td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>1</td>
+    <td></td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>1</td>
+    <td>0</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>3</td>
+    <td>0</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>3</td>
+    <td>1</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>9</td>
+    <td>1</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>9</td>
+    <td>2</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>27</td>
+    <td>2</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>27</td>
+    <td>3</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td>3</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td></td>
+    <td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td>4</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td></tr>
 </tbody>
 </table>
 
@@ -584,169 +574,169 @@ Enter exponent //exponent becomes "4"
 
 The table below lists the values of the local variables in this source file at different stages of execution:
 
-<table border="0">
+<table>
 <thead>
 <tr>
-<td align="center" colSpan="3">int</td>
-<td align="center" colSpan="4">int</td>
-<td align="center">int</td></tr>
-<tr><td align="center" colSpan="3">main(void)</td>
-<td align="center" colSpan="4">power(int base, int exponent)</td>
-<td align="center">getNonNegInt(void)</td></tr>
+<td colSpan="3">int</td>
+<td colSpan="4">int</td>
+<td>int</td></tr>
+<tr><td colSpan="3">main(void)</td>
+<td colSpan="4">power(int base, int exponent)</td>
+<td>getNonNegInt(void)</td></tr>
 </thead>
 <tbody>
-<tr><td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td>
-    <td align="center">int</td></tr>
-<tr><td align="center">base</td>
-    <td align="center">exp</td>
-    <td align="center">answer</td>
-    <td align="center">base</td>
-    <td align="center">exponent</td>
-    <td align="center">result</td>
-    <td align="center">i</td>
-    <td align="center">value</td></tr>
-<tr><td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center"></td>
-    <td align="center">-2</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">4</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">1</td>
-    <td align="center">?</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">1</td>
-    <td align="center">0</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">3</td>
-    <td align="center">0</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">3</td>
-    <td align="center">1</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">9</td>
-    <td align="center">1</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">9</td>
-    <td align="center">2</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">27</td>
-    <td align="center">2</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">27</td>
-    <td align="center">3</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center">3</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">?</td>
-    <td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center">4</td>
-    <td align="center">&nbsp;</td></tr>
-<tr><td align="center">3</td>
-    <td align="center">4</td>
-    <td align="center">81</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td>
-    <td align="center">&nbsp;</td></tr>
+<tr><td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td>
+    <td>int</td></tr>
+<tr><td>base</td>
+    <td>exp</td>
+    <td>answer</td>
+    <td>base</td>
+    <td>exponent</td>
+    <td>result</td>
+    <td>i</td>
+    <td>value</td></tr>
+<tr><td>?</td>
+    <td>?</td>
+    <td>?</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>?</td>
+    <td>?</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>?</td>
+    <td>?</td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>-2</td></tr>
+<tr><td>3</td>
+    <td>?</td>
+    <td>?</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>4</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>?</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>1</td>
+    <td>?</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>1</td>
+    <td>0</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>3</td>
+    <td>0</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>3</td>
+    <td>1</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>9</td>
+    <td>1</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>9</td>
+    <td>2</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>27</td>
+    <td>2</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>27</td>
+    <td>3</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td>3</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>?</td>
+    <td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td>4</td>
+    <td>&nbsp;</td></tr>
+<tr><td>3</td>
+    <td>4</td>
+    <td>81</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td></tr>
 </tbody>
 </table>
 

--- a/docs/D-Modularity/pointers.md
+++ b/docs/D-Modularity/pointers.md
@@ -200,77 +200,77 @@ Although `internal_swap()` does exchange the values in variables `a` and `b`, th
 
 The walkthrough table shows how the changes remain completely within `internal_swap()` function scope:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="3"><code>void</code></td>
-            <td align="center" colSpan="2"><code>int</code></td> 
+            <td colSpan="3"><code>void</code></td>
+            <td colSpan="2"><code>int</code></td> 
         </tr>
         <tr>
-            <td align="center" colSpan="3"><code>local_swap(int a, int b)</code></td>
-            <td align="center" colSpan="2"><code>main(void)</code></td> 
+            <td colSpan="3"><code>local_swap(int a, int b)</code></td>
+            <td colSpan="2"><code>main(void)</code></td> 
         </tr>
         <tr>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
         </tr>
         <tr>
-            <td align="center"><code>a</code></td>
-            <td align="center"><code>b</code></td>
-            <td align="center"><code>c</code></td>
-            <td align="center"><code>a</code></td>
-            <td align="center"><code>b</code></td>
+            <td><code>a</code></td>
+            <td><code>b</code></td>
+            <td><code>c</code></td>
+            <td><code>a</code></td>
+            <td><code>b</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF78</code></td>
-            <td align="center"><code>0x0012FF7C</code></td>
-            <td align="center"><code>0x0012FF6C</code></td>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>    
+            <td><code>0x0012FF78</code></td>
+            <td><code>0x0012FF7C</code></td>
+            <td><code>0x0012FF6C</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>    
         </tr>
         <tr>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
-        <tr><td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center">?</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-        </tr>
-        <tr>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+        <tr><td><code>5</code></td>
+            <td><code>6</code></td>
+            <td>?</td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>6</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+        </tr>
+        <tr>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
     </tbody>
 </table>
@@ -340,155 +340,155 @@ b is 5
 
 The walkthrough table shows how the changes carry over to `main()`:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="3"><code>void</code></td>
-            <td align="center" colSpan="2"><code>int</code></td>
+            <td colSpan="3"><code>void</code></td>
+            <td colSpan="2"><code>int</code></td>
         </tr>
-        <tr><td align="center" colSpan="3"><code>swap(int *p, int *q)</code></td>
-            <td align="center" colSpan="2"><code>main(void)</code></td>
-        </tr>
-        <tr>
-            <td align="center"><code>int *</code></td>
-            <td align="center"><code>int *</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
+        <tr><td colSpan="3"><code>swap(int *p, int *q)</code></td>
+            <td colSpan="2"><code>main(void)</code></td>
         </tr>
         <tr>
-            <td align="center"><code>p</code></td>
-            <td align="center"><code>q</code></td>
-            <td align="center"><code>c</code></td>
-            <td align="center"><code>a</code></td>
-            <td align="center"><code>b</code></td>
+            <td><code>int *</code></td>
+            <td><code>int *</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF78</code></td>
-            <td align="center"><code>0x0012FF7C</code></td>
-            <td align="center"><code>0x0012FF6C</code></td>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
+            <td><code>p</code></td>
+            <td><code>q</code></td>
+            <td><code>c</code></td>
+            <td><code>a</code></td>
+            <td><code>b</code></td>
+        </tr>
+        <tr>
+            <td><code>0x0012FF78</code></td>
+            <td><code>0x0012FF7C</code></td>
+            <td><code>0x0012FF6C</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
         </tr>
         <tr>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
-            <td align="center">?</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
+            <td>?</td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
         </tr>
     </tbody>
 </table>
 
 Some programmers prefer symbolic notation instead of address values. For example, they use the symbol `main::a` to refer to the local variable `a` in the function `main()`. A walkthrough table using symbolic notation looks something like this:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center" colSpan="3"><code>void</code></td>
-            <td align="center" colSpan="2"><code>int</code></td>
+            <td colSpan="3"><code>void</code></td>
+            <td colSpan="2"><code>int</code></td>
         </tr>
         <tr>
-            <td align="center" colSpan="3"><code>swap(int *p, int *q)</code></td>
-            <td align="center" colSpan="2"><code>main(void)</code></td>
+            <td colSpan="3"><code>swap(int *p, int *q)</code></td>
+            <td colSpan="2"><code>main(void)</code></td>
         </tr>
         <tr>
-            <td align="center"><code>int *</code></td>
-            <td align="center"><code>int *</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
-            <td align="center"><code>int</code></td>
+            <td><code>int *</code></td>
+            <td><code>int *</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
+            <td><code>int</code></td>
         </tr>
         <tr>
-            <td align="center"><code>p</code></td>
-            <td align="center"><code>q</code></td>
-            <td align="center"><code>c</code></td>
-            <td align="center"><code>a</code></td>
-            <td align="center"><code>b</code></td>
+            <td><code>p</code></td>
+            <td><code>q</code></td>
+            <td><code>c</code></td>
+            <td><code>a</code></td>
+            <td><code>b</code></td>
         </tr>
         <tr>
-            <td align="center"><code>0x0012FF78</code></td>
-            <td align="center"><code>0x0012FF7C</code></td>
-            <td align="center"><code>0x0012FF6C</code></td>
-            <td align="center"><code>0x0012FF88</code></td>
-            <td align="center"><code>0x0012FF84</code></td>
+            <td><code>0x0012FF78</code></td>
+            <td><code>0x0012FF7C</code></td>
+            <td><code>0x0012FF6C</code></td>
+            <td><code>0x0012FF88</code></td>
+            <td><code>0x0012FF84</code></td>
         </tr>
         <tr>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>main::a</code></td>
-            <td align="center"><code>main::b</code></td>
-            <td align="center">?</td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>main::a</code></td>
+            <td><code>main::b</code></td>
+            <td>?</td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>main::a</code></td>
-            <td align="center"><code>main::b</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>main::a</code></td>
+            <td><code>main::b</code></td>
+            <td><code>5</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>main::a</code></td>
-            <td align="center"><code>main::b</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>6</code></td>
+            <td><code>main::a</code></td>
+            <td><code>main::b</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>6</code></td>
         </tr>
         <tr>
-            <td align="center"><code>main::a</code></td>
-            <td align="center"><code>main::b</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
+            <td><code>main::a</code></td>
+            <td><code>main::b</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
         </tr>
         <tr>
-            <td align="center"><code>main::a</code></td>
-            <td align="center"><code>main::b</code></td>
-            <td align="center"><code>5</code></td>
-            <td align="center"><code>6</code></td>
-            <td align="center"><code>5</code></td>
+            <td><code>main::a</code></td>
+            <td><code>main::b</code></td>
+            <td><code>5</code></td>
+            <td><code>6</code></td>
+            <td><code>5</code></td>
         </tr>
     </tbody>
 </table>

--- a/docs/F-Refinements/character-strings.md
+++ b/docs/F-Refinements/character-strings.md
@@ -24,10 +24,10 @@ This chapter introduces these C-style strings, highlights their distinguishing f
 
 A string is a `char` array with a special property which is a terminator element that follows the last **_meaningful character_** in the string. We refer to this terminator as the **null terminator** and identify it by the escape sequence `'\0'`.
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="18" align="center">char</td>
+            <td colSpan="18">char</td>
         </tr>
         <tr>
             <td>&nbsp;</td>
@@ -59,10 +59,10 @@ The **null terminator** has the integral value of `0` on any host platform (in i
 
 The index identifying the null terminator element is the same as the number of meaningful characters in the string (including spaces between words).
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="18" align="center">char<br/>name</td>
+            <td colSpan="18">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -137,10 +137,10 @@ const char name[31] = "My name is Arnold";  // null-byte is automatically append
 
 The C compiler copies the characters in the string literal into the character string and appends the null-byte terminator after the last copied character.
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -311,10 +311,10 @@ scanf("%s", name);  // <=== User enters: My name is Arnold
 
 The `scanf()` function will stop accepting input after the character `y` and stores the following:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -396,10 +396,10 @@ scanf("%10s", name); // <=== User enters: Schwartzenegger
 
 The `scanf()` function will stop accepting input after the character `n` and stores the following:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -483,10 +483,10 @@ scanf("%10s", name);  // <=== User enters: '          Schwartzenegger'
 
 Just as before, the `scanf()` function will stop accepting input after the character `n` but will also discard the leading spaces entered and stores the following:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -579,10 +579,10 @@ scanf("%[^\n]", name);  // <=== User enters: My name is Arnold
 
 The `scanf()` function accepts the full line an stores:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -662,10 +662,10 @@ scanf("%10[^\n]", name);  // <=== User enters: My name is Arnold
 
 The `scanf()` function will store:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>
@@ -749,10 +749,10 @@ scanf("%10[^\n]", name);  // <=== User enters: '          My name is Arnold'
 
 The `scanf()` function will store:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td colSpan="31" align="center">char<br/>name</td>
+            <td colSpan="31">char<br/>name</td>
         </tr>
         <tr>
             <td>0</td>

--- a/docs/Resources-Appendices/data-conversions.md
+++ b/docs/Resources-Appendices/data-conversions.md
@@ -35,54 +35,54 @@ To convert a binary number to its hexadecimal equivalent, we:
 
 Consider the 8-bit number **01011100<sub>2</sub>**:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
             <td>Nibble #</td>
-            <td colSpan="4" align="center">1</td>
-            <td colSpan="4" align="center">0</td>
+            <td colSpan="4">1</td>
+            <td colSpan="4">0</td>
         </tr>
         <tr>
             <td>Bit #</td>
-            <td align="center">7</td>
-            <td align="center">6</td>
-            <td align="center">5</td>
-            <td align="center">4</td>
-            <td align="center">3</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
+            <td>7</td>
+            <td>6</td>
+            <td>5</td>
+            <td>4</td>
+            <td>3</td>
+            <td>2</td>
+            <td>1</td>
+            <td>0</td>
         </tr>
         <tr>
             <td>Multiplier</td>
-            <td align="center">8</td>
-            <td align="center">4</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">8</td>
-            <td align="center">4</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
+            <td>8</td>
+            <td>4</td>
+            <td>2</td>
+            <td>1</td>
+            <td>8</td>
+            <td>4</td>
+            <td>2</td>
+            <td>1</td>
         </tr>
         <tr>
             <td>Contents</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">0</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
         </tr>
         <tr>
             <td>Nibble Values</td>
-            <td colSpan="4" align="center">0*8 + 1*4 + 0*2 + 1*1 = 0x5</td>
-            <td colSpan="4" align="center">1*8 + 1*4 + 0*2 + 1*0 = 0xC</td>
+            <td colSpan="4">0*8 + 1*4 + 0*2 + 1*1 = 0x5</td>
+            <td colSpan="4">1*8 + 1*4 + 0*2 + 1*0 = 0xC</td>
         </tr>
         <tr>
             <td>Byte Value</td>
-            <td colSpan="8" align="center">0x5C</td>
+            <td colSpan="8">0x5C</td>
         </tr>
     </tbody>
 </table>
@@ -110,49 +110,49 @@ Consider the hexadecimal number **0x5C**:
 - Take the result (0x1), divide it by 2 and put the remainder (1) in bit 6
 - Take the result (0x0), divide it by 2 and put the remainder (0) in bit 7
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center">Bit#</td>
-            <td align="center">7</td>
-            <td align="center">6</td>
-            <td align="center">5</td>
-            <td align="center">4</td>
-            <td align="center">3</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
+            <td>Bit#</td>
+            <td>7</td>
+            <td>6</td>
+            <td>5</td>
+            <td>4</td>
+            <td>3</td>
+            <td>2</td>
+            <td>1</td>
+            <td>0</td>
         </tr>
         <tr>
-            <td align="center">Byte Value</td>
-            <td colSpan="8" align="center">0x5C</td>
+            <td>Byte Value</td>
+            <td colSpan="8">0x5C</td>
         </tr>
         <tr>
-            <td align="center">Nibble Values</td>
-            <td colSpan="4" align="center">0x5</td>
-            <td colSpan="4" align="center">0xC</td>
+            <td>Nibble Values</td>
+            <td colSpan="4">0x5</td>
+            <td colSpan="4">0xC</td>
         </tr>
         <tr>
-            <td align="center">Divide by 2</td>
-            <td align="center">0</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">2</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">3</td>
-            <td align="center">6</td>
+            <td>Divide by 2</td>
+            <td>0</td>
+            <td>0</td>
+            <td>1</td>
+            <td>2</td>
+            <td>0</td>
+            <td>1</td>
+            <td>3</td>
+            <td>6</td>
         </tr>
         <tr>
-            <td align="center">Bit Values</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">0</td>
+            <td>Bit Values</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
         </tr>
     </tbody>
 </table>
@@ -179,40 +179,40 @@ Consider the value **92**:
 - Take the result (**1**), divide it by 2 and store the remainder (**1**) in bit 6
 - Take the result (**0**), divide it by 2 and store the remainder (**0**) in bit 7
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center">Bit#</td>
-            <td align="center">7</td>
-            <td align="center">6</td>
-            <td align="center">5</td>
-            <td align="center">4</td>
-            <td align="center">3</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
+            <td>Bit#</td>
+            <td>7</td>
+            <td>6</td>
+            <td>5</td>
+            <td>4</td>
+            <td>3</td>
+            <td>2</td>
+            <td>1</td>
+            <td>0</td>
         </tr>
         <tr>
-            <td align="center">Value</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">2</td>
-            <td align="center">5</td>
-            <td align="center">11</td>
-            <td align="center">23</td>
-            <td align="center">46</td>
-            <td align="center">92</td>
+            <td>Value</td>
+            <td>0</td>
+            <td>1</td>
+            <td>2</td>
+            <td>5</td>
+            <td>11</td>
+            <td>23</td>
+            <td>46</td>
+            <td>92</td>
         </tr>
         <tr>
-            <td align="center">Bit Values</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">0</td>
+            <td>Bit Values</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
         </tr>
     </tbody>
 </table>
@@ -223,55 +223,55 @@ To convert a binary number into its decimal equivalent, we multiply the value in
 
 Consider the 8-bit binary number **01011100<sub>2</sub>**:
 
-<table border="0">
+<table>
     <tbody>
         <tr>
-            <td align="center">Bit #</td>
-            <td align="center">7</td>
-            <td align="center">6</td>
-            <td align="center">5</td>
-            <td align="center">4</td>
-            <td align="center">3</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
+            <td>Bit #</td>
+            <td>7</td>
+            <td>6</td>
+            <td>5</td>
+            <td>4</td>
+            <td>3</td>
+            <td>2</td>
+            <td>1</td>
+            <td>0</td>
         </tr>
         <tr>
-            <td align="center">Power of 2</td>
-            <td align="center">7</td>
-            <td align="center">6</td>
-            <td align="center">5</td>
-            <td align="center">4</td>
-            <td align="center">3</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
+            <td>Power of 2</td>
+            <td>7</td>
+            <td>6</td>
+            <td>5</td>
+            <td>4</td>
+            <td>3</td>
+            <td>2</td>
+            <td>1</td>
+            <td>0</td>
         </tr>
         <tr>
-            <td align="center">Bit Values</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">1</td>
-            <td align="center">0</td>
-            <td align="center">0</td>
+            <td>Bit Values</td>
+            <td>0</td>
+            <td>1</td>
+            <td>0</td>
+            <td>1</td>
+            <td>1</td>
+            <td>1</td>
+            <td>0</td>
+            <td>0</td>
         </tr>
         <tr>
-            <td align="center">Multiplier</td>
-            <td align="center">128</td>
-            <td align="center">64</td>
-            <td align="center">32</td>
-            <td align="center">16</td>
-            <td align="center">8</td>
-            <td align="center">4</td>
-            <td align="center">2</td>
-            <td align="center">1</td>
+            <td>Multiplier</td>
+            <td>128</td>
+            <td>64</td>
+            <td>32</td>
+            <td>16</td>
+            <td>8</td>
+            <td>4</td>
+            <td>2</td>
+            <td>1</td>
         </tr>
         <tr>
-            <td align="center">Byte Value</td>
-            <td colSpan="8" align="center">0*128 + 1*64 + 0*32 + 1*16 + 1*8 + 1*4 + 0*2 + 0*1 = 92</td>
+            <td>Byte Value</td>
+            <td colSpan="8">0*128 + 1*64 + 0*32 + 1*16 + 1*8 + 1*4 + 0*2 + 0*1 = 92</td>
         </tr>
     </tbody>
 </table>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,12 +47,12 @@ td {
   text-align: center;
 }
 
-tr.highlight td {
-  background-color: rgb(255, 255, 224);
+.highlight {
+  background-color: rgb(255, 255, 224) !important;
 }
 
-html[data-theme='dark'] tr.highlight td {
-  background-color: rgb(72, 77, 91);
+html[data-theme='dark'] .highlight {
+  background-color: rgb(72, 77, 91) !important;
 }
 
 html[data-theme='dark'] p img {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -43,12 +43,18 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
 
-div.mdImg {
-  background-color: #ffffff;
+td {
   text-align: center;
 }
 
-img {
-  display: block;
-  margin: auto;
+tr.highlight td {
+  background-color: rgb(255, 255, 224);
+}
+
+html[data-theme='dark'] tr.highlight td {
+  background-color: rgb(72, 77, 91);
+}
+
+html[data-theme='dark'] p img {
+  background-color: rgb(255, 255, 255);
 }


### PR DESCRIPTION
Closes #112 

Changes:

- Created CSS class for cell highlighting using two different colours (light vs dark mode)
- Added white background to images in dark mode

![light](https://user-images.githubusercontent.com/59708190/145166448-12d107b1-7c34-43b8-8ee8-38fbc9828c0c.PNG)

![dark](https://user-images.githubusercontent.com/59708190/145166465-6fa714f9-63d0-4aaf-b91d-cce2194eb54c.PNG)

Before:

![dark2](https://user-images.githubusercontent.com/59708190/145166495-78cd4fca-1350-453f-a356-1df23f6737a2.PNG)

After: 

![dark1](https://user-images.githubusercontent.com/59708190/145166477-5ff00de0-a7d6-4962-84f0-d0c81dd609f5.PNG)