### PR TITLE
Fix admonition in more-input-and-output file

### DIFF
--- a/docs/F-Refinements/more-input-and-output.md
+++ b/docs/F-Refinements/more-input-and-output.md
@@ -366,7 +366,8 @@ The conversion specifiers include:
 - `%n` does not output any characters but instead returns the number of characters processed so far.
 - **_Scientific_** (`%e` `%E`) refers to output in mantissa/exponent form `d.dddEdd` (for example, `0.123e3`, which stands for `0.123 x 103` or `123.0`).
 - **_General_** (`%g` `%G`) refers to output in the shortest form possible; decimal or mantissa/exponent (for example, `0.123e-5` rather than `0.00000123` and `3.1` rather than `0.31e1`).
-  :::
+
+:::
 
 ### Conversion Control
 


### PR DESCRIPTION
I checked `more-input-and-output.md` file, and there is syntax error in the `Remarks` note, the admonition `:::` has extra white space, and that is the reason why half of the page is "admonitioned".

This is the issue the page currently having now
![before-fixing](https://user-images.githubusercontent.com/69607880/145877369-9e365968-8177-4a09-a828-a51da61fa2ad.png)

And after removing extra white space in `more-input-and-output.md` file:
![image](https://user-images.githubusercontent.com/69607880/145877550-dd9997d7-d45a-4d05-b286-49c05a94e66e.png)

