### PR TITLE
Force git to use Unix end-of-line via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.jpeg binary


### PR DESCRIPTION
This will change how git works locally, using Unix end-of-line characters vs. whatever OS the user is working on.  Doing so will mean that Prettier won't complain about all files being in the wrong format.

You can read more about how this works at https://git-scm.com/docs/gitattributes#_text.